### PR TITLE
[DT-041672] Module Dependencies Dialog: An error is displayed when adding the 'Decisions.TruBot' module in a project.

### DIFF
--- a/Decisions.TruBot/Decisions.TruBot.csproj
+++ b/Decisions.TruBot/Decisions.TruBot.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DecisionsSDK" Version="9.0.3-beta" />
+    <PackageReference Include="DecisionsSDK" Version="9.2.0-beta" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
In version 9.2 the method "CreateFolderIfNotExistsAndSendEvent" had its signature updated. Because of this, the TruBot module code was not able to call it, throwing an exception that the method does not exist. I have updated the module to use the 9.2.0-beta nuget package